### PR TITLE
Fix support radius in zonotope.enclosePoints

### DIFF
--- a/contSet/@zonotope/enclosePoints.m
+++ b/contSet/@zonotope/enclosePoints.m
@@ -146,7 +146,7 @@ function Z = aux_cloud2zonotope(X,ratio,s1)
         end
         [U,~] = svd(X);
         u = U(:,1);
-        g = ratio * dot(abs(u),r) * u;
+        g = ratio * abs(dot(u , r)) * u;
         X = aux_compress(X,g);
         c = c + mid;
         R = [R g];

--- a/contSet/@zonotope/enclosePoints.m
+++ b/contSet/@zonotope/enclosePoints.m
@@ -43,7 +43,7 @@ function Z = enclosePoints(points,varargin)
 % Last revision: ---
 
 % ------------------------------ BEGIN CODE -------------------------------
-    
+
     % parse input arguments
     method = setDefaultValues({'maiga'},varargin);
 
@@ -146,7 +146,7 @@ function Z = aux_cloud2zonotope(X,ratio,s1)
         end
         [U,~] = svd(X);
         u = U(:,1);
-        g = ratio * abs(dot(u , r)) * u;
+        g = ratio * dot(abs(u),r) * u;
         X = aux_compress(X,g);
         c = c + mid;
         R = [R g];
@@ -161,11 +161,16 @@ end
 
 function X = aux_compress(X,g)
 % implementation of the compress function in [2]
-    
-    u = g/norm(g);
+
+    ng = norm(g);
+    if ng == 0
+        return
+    end
+
+    u = g/ng;
     for i=1:size(X,2)
        d = dot(X(:,i) , u);
-       d = min(norm(g),max(-norm(g),d));
+       d = min(ng,max(-ng,d));
        X(:,i) = X(:,i) - (d * u);
     end
 end

--- a/unitTests/contSet/zonotope/test_zonotope_enclosePoints.m
+++ b/unitTests/contSet/zonotope/test_zonotope_enclosePoints.m
@@ -44,15 +44,10 @@ Z_ = zonotope.enclosePoints(p,'stursberg');
 assert(all(contains(Z,p)))
 assert(all(contains(Z_,p)))
 
-% check degenerate and sign-cancelling point clouds
+% check degenerate point cloud
 pDegenerate = repmat([1; -2],1,4);
 ZDegenerate = zonotope.enclosePoints(pDegenerate);
 assert(all(isfinite([ZDegenerate.c; ZDegenerate.G(:)])))
 assert(all(contains(ZDegenerate,pDegenerate)))
-
-pCancellation = [1 -1; -1 1];
-ZCancellation = zonotope.enclosePoints(pCancellation);
-assert(all(isfinite([ZCancellation.c; ZCancellation.G(:)])))
-assert(all(contains(ZCancellation,pCancellation)))
 
 % ------------------------------ END OF CODE ------------------------------

--- a/unitTests/contSet/zonotope/test_zonotope_enclosePoints.m
+++ b/unitTests/contSet/zonotope/test_zonotope_enclosePoints.m
@@ -22,7 +22,7 @@ function res = test_zonotope_enclosePoints
 % Last revision: ---
 
 % ------------------------------ BEGIN CODE -------------------------------
- 
+
 % assume true
 res = true;
 
@@ -43,5 +43,16 @@ Z_ = zonotope.enclosePoints(p,'stursberg');
 % check if all points are contained
 assert(all(contains(Z,p)))
 assert(all(contains(Z_,p)))
+
+% check degenerate and sign-cancelling point clouds
+pDegenerate = repmat([1; -2],1,4);
+ZDegenerate = zonotope.enclosePoints(pDegenerate);
+assert(all(isfinite([ZDegenerate.c; ZDegenerate.G(:)])))
+assert(all(contains(ZDegenerate,pDegenerate)))
+
+pCancellation = [1 -1; -1 1];
+ZCancellation = zonotope.enclosePoints(pCancellation);
+assert(all(isfinite([ZCancellation.c; ZCancellation.G(:)])))
+assert(all(contains(ZCancellation,pCancellation)))
 
 % ------------------------------ END OF CODE ------------------------------


### PR DESCRIPTION
## Summary

Fixes the support-radius calculation in `zonotope.enclosePoints` and prevents a
zero generator from being normalized during residual-cloud compression.

Closes #79.

## Problem

The previous implementation used `abs(dot(u,r))`, where `r` is the nonnegative
radius vector of an axis-aligned interval and `u` is the selected direction.
Opposite signs in `u` can cancel even when the interval has nonzero extent. For
example, `u = [-1; 1] / sqrt(2)` and `r = [1; 1]` yield a zero dot product, after
which normalizing the zero generator introduces non-finite values.

## Fix

- use `dot(abs(u),r)`, the support radius of the axis-aligned interval in direction `u`
- return from compression when the generated direction has zero norm
- add regression coverage for a degenerate point cloud and a sign-cancelling cloud

## Validation

- verified the sign-cancellation reproduction independently
- verified that `dot(abs(u),r)` equals the maximum absolute projection over the interval vertices
- checked the final diff against upstream `master`; only the implementation and focused unit test change
- ran `git diff --check` successfully
- MATLAB and Octave are not installed locally, so the MATLAB unit test was not executed locally
